### PR TITLE
Options

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,8 @@
+= Changelog
+
+== v2.0.3
+* Rid of errors /dev/stderr during closer because of sync - we use OTEL Logger closer for final sync now
+* Allow disable OTEL prapagation `OTEL_ENABLE`
+* `NewSimple` constructor without OTEL
+* Implement options more gracefully OTEL initialization
+* Monitor temporary remove. We should create more clear concept of that

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,4 +5,4 @@
 * Allow disable OTEL prapagation `OTEL_ENABLE`
 * `NewSimple` constructor without OTEL
 * Implement options more gracefully OTEL initialization
-* Monitor temporary remove. We should create more clear concept of that
+* Monitor uses options flow for setup and add as composition to Telemetry for `AddHealthChecker` health attach

--- a/README.adoc
+++ b/README.adoc
@@ -65,10 +65,16 @@ sentry dns
 
 `type`: string
 
+.MONITOR_ENABLE
+default: `true`
+
 .MONITOR_ADDR
 address where `health`, `prometheus` would be listen
 
 NOTE: address logic represented in net.Listen description
+
+.OTEL_ENABLE
+default: `true`
 
 .OTEL_COLLECTOR_GRPC_ADDR
 Address to otel collector server via GRPC protocol

--- a/TODO.adoc
+++ b/TODO.adoc
@@ -1,0 +1,3 @@
+= ToDo
+* move metrics to OTEL from all middlewares
+* integrate monitor with OTEL Metric

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ const (
 	envLogEncode = "LOG_ENCODE"
 
 	envDebug      = "DEBUG"
+	envMonEnable  = "MONITOR_ENABLE"
 	envMon        = "MONITOR_ADDR"
 	envOtelEnable = "OTEL_ENABLE"
 	evnOtel       = "OTEL_COLLECTOR_GRPC_ADDR"
@@ -34,6 +35,11 @@ type OtelConfig struct {
 	WithInsecure bool   `env:"OTEL_EXPORTER_WITH_INSECURE" envDefault:"true"`
 }
 
+type MonitorConfig struct {
+	Enable      bool   `env:"MONITOR_ENABLE" envDefault:"true"`
+	MonitorAddr string `env:"MONITOR_ADDR" envDefault:"0.0.0.0:8011"`
+}
+
 type Config struct {
 	Service   string `env:"OTEL_SERVICE_NAME"`
 	Namespace string `env:"NAMESPACE"`
@@ -43,8 +49,7 @@ type Config struct {
 	LogEncode string `env:"LOG_ENCODE" envDefault:"json"`
 	Debug     bool   `env:"DEBUG" envDefault:"false"`
 
-	MonitorAddr string `env:"MONITOR_ADDR" envDefault:"0.0.0.0:8011"`
-
+	MonitorConfig
 	OtelConfig
 }
 
@@ -53,12 +58,15 @@ func DefaultConfig() Config {
 	host = strings.ToLower(strings.ReplaceAll(host, "-", "_"))
 
 	return Config{
-		Service:     host,
-		Version:     "dev",
-		Namespace:   "default",
-		LogEncode:   "json",
-		LogLevel:    "info",
-		MonitorAddr: "0.0.0.0:8011",
+		Service:   host,
+		Version:   "dev",
+		Namespace: "default",
+		LogEncode: "json",
+		LogLevel:  "info",
+		MonitorConfig: MonitorConfig{
+			Enable:      true,
+			MonitorAddr: "0.0.0.0:8011",
+		},
 		OtelConfig: OtelConfig{
 			Addr:         "127.0.0.1:4317",
 			WithInsecure: true,
@@ -102,7 +110,8 @@ func GetConfigFromEnv() Config {
 	bl(envOtelInsec, &c.OtelConfig.WithInsecure)
 
 	bl(envDebug, &c.Debug)
-	bl(envOtelEnable, &c.Enable)
+	bl(envOtelEnable, &c.OtelConfig.Enable)
+	bl(envMonEnable, &c.MonitorConfig.Enable)
 
 	return c
 }

--- a/config.go
+++ b/config.go
@@ -18,15 +18,17 @@ const (
 	envLogLevel  = "LOG_LEVEL"
 	envLogEncode = "LOG_ENCODE"
 
-	envDebug     = "DEBUG"
-	envMon       = "MONITOR_ADDR"
-	evnOtel      = "OTEL_COLLECTOR_GRPC_ADDR"
-	envOtelInsec = "OTEL_EXPORTER_WITH_INSECURE"
+	envDebug      = "DEBUG"
+	envMon        = "MONITOR_ADDR"
+	envOtelEnable = "OTEL_ENABLE"
+	evnOtel       = "OTEL_COLLECTOR_GRPC_ADDR"
+	envOtelInsec  = "OTEL_EXPORTER_WITH_INSECURE"
 )
 
 const DisableLog = "none"
 
 type OtelConfig struct {
+	Enable bool `env:"OTEL_ENABLE" envDefault:"true"`
 	// OtelAddr address where grpc open-telemetry exporter serve
 	Addr         string `env:"OTEL_COLLECTOR_GRPC_ADDR" envDefault:"0.0.0.0:4317"`
 	WithInsecure bool   `env:"OTEL_EXPORTER_WITH_INSECURE" envDefault:"true"`
@@ -60,6 +62,7 @@ func DefaultConfig() Config {
 		OtelConfig: OtelConfig{
 			Addr:         "127.0.0.1:4317",
 			WithInsecure: true,
+			Enable:       true,
 		},
 	}
 }
@@ -99,6 +102,7 @@ func GetConfigFromEnv() Config {
 	bl(envOtelInsec, &c.OtelConfig.WithInsecure)
 
 	bl(envDebug, &c.Debug)
+	bl(envOtelEnable, &c.Enable)
 
 	return c
 }

--- a/construct.go
+++ b/construct.go
@@ -6,25 +6,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
-	"time"
 
-	"github.com/d7561985/tel/v2/otlplog/logskd"
-	"github.com/d7561985/tel/v2/otlplog/otlploggrpc"
-	"github.com/d7561985/tel/v2/pkg/zlogfmt"
-	"go.opentelemetry.io/contrib/instrumentation/host"
-	rt "go.opentelemetry.io/contrib/instrumentation/runtime"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/metric/global"
-	"go.opentelemetry.io/otel/propagation"
-	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
-	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
-	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
 	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -73,7 +56,7 @@ func genInstanceID(srv string) string {
 	return instance
 }
 
-func newLogger(ctx context.Context, res *resource.Resource, l Config) (*zap.Logger, func(ctx context.Context)) {
+func newLogger(l Config) *zap.Logger {
 	var lvl zapcore.Level
 
 	handleErr(lvl.Set(l.LogLevel), fmt.Sprintf("zap set log lever %q", l.LogLevel))
@@ -94,118 +77,11 @@ func newLogger(ctx context.Context, res *resource.Resource, l Config) (*zap.Logg
 		zap.AddStacktrace(zapcore.ErrorLevel),
 		zap.IncreaseLevel(lvl),
 	)
-
 	handleErr(err, "zap build")
-
-	// exporter part
-	// this initiation controversy SRP, but right now we just speed up our development
-	opts := []otlploggrpc.Option{otlploggrpc.WithEndpoint(l.OtelConfig.Addr)}
-	if l.WithInsecure {
-		opts = append(opts, otlploggrpc.WithInsecure())
-	}
-
-	logExporter, err := otlploggrpc.New(ctx, res, opts...)
-	handleErr(err, "Failed to create the collector log exporter")
-
-	batcher := logskd.NewBatchLogProcessor(logExporter)
-	cc := zlogfmt.NewCore(batcher)
-
-	pl = pl.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-		return zapcore.NewTee(core, cc)
-	}))
 
 	zap.ReplaceGlobals(pl)
 
-	// grpc error logger, we use it for debug connection to collector at least
-	//grpclog.SetLoggerV2(grpcerr.New(pl))
-
-	// otel handler also intersect logs
-	//otel.SetErrorHandler(otelerr.New(pl))
-
-	return pl, func(ctx context.Context) {
-		handleErr(batcher.Shutdown(ctx), "batched shutdown")
-	}
-}
-
-func newOtlpMetic(ctx context.Context, res *resource.Resource, l Config) func(ctx context.Context) {
-	opts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(l.OtelConfig.Addr)}
-	if l.OtelConfig.WithInsecure {
-		opts = append(opts, otlpmetricgrpc.WithInsecure())
-	}
-
-	metricClient := otlpmetricgrpc.NewClient(opts...,
-	//otlpmetricgrpc.WithDialOption(grpc.WithBlock()),
-	)
-
-	metricExp, err := otlpmetric.New(ctx, metricClient)
-	handleErr(err, "Failed to create the collector metric exporter")
-
-	pusher := controller.New(
-		processor.NewFactory(
-			simple.NewWithHistogramDistribution(),
-			metricExp,
-			processor.WithMemory(true),
-		),
-		controller.WithExporter(metricExp),
-		controller.WithCollectPeriod(5*time.Second),
-		controller.WithResource(res),
-	)
-	global.SetMeterProvider(pusher)
-
-	err = pusher.Start(ctx)
-	handleErr(err, "Failed to start metric pusher")
-
-	// runtime exported
-	err = rt.Start()
-	handleErr(err, "Failed to start runtime metric")
-
-	// host metrics exporter
-	err = host.Start()
-	handleErr(err, "Failed to start host metric")
-
-	return func(cxt context.Context) {
-		// pushes any last exports to the receiver
-		if err = pusher.Stop(cxt); err != nil {
-			otel.Handle(err)
-		}
-	}
-}
-
-// OtraceInit init exporter which should be properly closed
-//user otel.GetTracerProvider() to rieach trace
-func newOtlpTrace(ctx context.Context, res *resource.Resource, l Config) func(ctx context.Context) {
-	opts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(l.OtelConfig.Addr)}
-	if l.OtelConfig.WithInsecure {
-		opts = append(opts, otlptracegrpc.WithInsecure())
-	}
-
-	traceClient := otlptracegrpc.NewClient(opts...,
-	//otlptracegrpc.WithDialOption(grpc.WithBlock()),
-	)
-
-	traceExp, err := otlptrace.New(ctx, traceClient)
-	handleErr(err, "Failed to create the collector trace exporter")
-
-	bsp := sdktrace.NewBatchSpanProcessor(traceExp)
-	tracerProvider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithResource(res),
-		sdktrace.WithSpanProcessor(bsp),
-	)
-
-	// set global propagator to tracecontext (the default is no-op).
-	otel.SetTextMapPropagator(
-		propagation.NewCompositeTextMapPropagator(
-			propagation.TraceContext{}, propagation.Baggage{},
-		))
-
-	otel.SetTracerProvider(tracerProvider)
-
-	return func(cxt context.Context) {
-		if err = traceExp.Shutdown(cxt); err != nil {
-			otel.Handle(err)
-		}
-	}
+	return pl
 }
 
 func newMonitor(cfg Config) Monitor {

--- a/example/demo/client/go.mod
+++ b/example/demo/client/go.mod
@@ -2,10 +2,8 @@ module client
 
 go 1.17
 
-replace github.com/d7561985/tel => ../../..
-
 require (
-	github.com/d7561985/tel/v2 v2.0.1
+	github.com/d7561985/tel/v2 v2.0.0-00010101000000-000000000000
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0
 	go.opentelemetry.io/otel v1.4.1
 	go.opentelemetry.io/otel/metric v0.26.0
@@ -17,7 +15,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/d7561985/tel v0.0.0-00010101000000-000000000000 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.2 // indirect
@@ -57,3 +54,5 @@ require (
 	google.golang.org/grpc v1.42.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 )
+
+replace github.com/d7561985/tel/v2 => ../../..

--- a/example/demo/client/go.sum
+++ b/example/demo/client/go.sum
@@ -30,10 +30,6 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/d7561985/tel/v2 v2.0.0 h1:pG1nzDAbjeiPUAF2Ss9LnKK53ZRLUt5VtfqwCAFXuSs=
-github.com/d7561985/tel/v2 v2.0.0/go.mod h1:JU4LF6gUXG4MqrN5TPohbl8oAlynLdKAM94j+p0xtms=
-github.com/d7561985/tel/v2 v2.0.1 h1:XfUq+dNnF6Hg6U4DPkqhdy8bkbCT1ra/qIV288bmyG0=
-github.com/d7561985/tel/v2 v2.0.1/go.mod h1:JU4LF6gUXG4MqrN5TPohbl8oAlynLdKAM94j+p0xtms=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/example/demo/client/main.go
+++ b/example/demo/client/main.go
@@ -59,12 +59,7 @@ func main() {
 	teleCtx := tel.WithContext(ccx, t)
 	ctx := baggage.ContextWithBaggage(teleCtx, bag)
 
-	go t.M().
-		AddHealthChecker(ctx, tel.HealthChecker{Handler: health.NewCompositeChecker()}).
-		//AddMetricTracker().
-		Start(ctx)
-
-	defer t.M().GracefulStop(context.Background())
+	t.AddHealthChecker(ctx, tel.HealthChecker{Handler: health.NewCompositeChecker()})
 
 	go func() {
 		cn := make(chan os.Signal, 1)

--- a/go.sum
+++ b/go.sum
@@ -52,11 +52,9 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.1 h1:DX7uPQ4WgAWfoh+NGGlbJQswnYIVvz0SRlLS3rPZQDA=
 github.com/go-logr/logr v1.2.1/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
@@ -89,8 +87,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -182,7 +180,6 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.27.0/go.mod h1:
 go.opentelemetry.io/contrib/instrumentation/runtime v0.27.0 h1:0VckNFxrgunf4bpAFcgyqwvBedyP53cK+MMlU/9O788=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.27.0/go.mod h1:6ZYYPfSKyhnkpw3xOssb1PMclnNs8dnSzO5POa+02ys=
 go.opentelemetry.io/otel v1.2.0/go.mod h1:aT17Fk0Z1Nor9e0uisf98LrntPGMnk4frBO9+dkf69I=
-go.opentelemetry.io/otel v1.3.0 h1:APxLf0eiBwLl+SOXiJJCVYzA1OOJNyAoV8C5RNRyy7Y=
 go.opentelemetry.io/otel v1.3.0/go.mod h1:PWIKzi6JCp7sM0k9yZ43VX+T345uNbAkDKwHVjb2PTs=
 go.opentelemetry.io/otel v1.4.1 h1:QbINgGDDcoQUoMJa2mMaWno49lja9sHwp6aoa2n3a4g=
 go.opentelemetry.io/otel v1.4.1/go.mod h1:StM6F/0fSwpd8dKWDCdRr7uRvEPYdW0hBSlbdTiUde4=
@@ -210,7 +207,6 @@ go.opentelemetry.io/otel/sdk/export/metric v0.26.0/go.mod h1:UpqzSnUOjFeSIVQLPp3
 go.opentelemetry.io/otel/sdk/metric v0.26.0 h1:7IKp3gc/ObieCtshBeYYVFp3ZP7xIH1OzODi1Wao90Y=
 go.opentelemetry.io/otel/sdk/metric v0.26.0/go.mod h1:2VIeK0kS1YvRLFg3J58ptZTXYpiWlkq2n5RQt6w7He8=
 go.opentelemetry.io/otel/trace v1.2.0/go.mod h1:N5FLswTubnxKxOJHM7XZC074qpeEdLy3CgAVsdMucK0=
-go.opentelemetry.io/otel/trace v1.3.0 h1:doy8Hzb1RJ+I3yFhtDmwNc7tIyw1tNMOIsyPzp1NOGY=
 go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=
 go.opentelemetry.io/otel/trace v1.4.1 h1:O+16qcdTrT7zxv2J6GejTPFinSwA++cYerC5iSiF8EQ=
 go.opentelemetry.io/otel/trace v1.4.1/go.mod h1:iYEVbroFCNut9QkwEczV9vMRPHNKSSwYZjulEtsmhFc=

--- a/options.go
+++ b/options.go
@@ -1,0 +1,173 @@
+package tel
+
+import (
+	"context"
+	"time"
+
+	"github.com/d7561985/tel/v2/otlplog/logskd"
+	"github.com/d7561985/tel/v2/otlplog/otlploggrpc"
+	"github.com/d7561985/tel/v2/pkg/zlogfmt"
+	"go.opentelemetry.io/contrib/instrumentation/host"
+	rt "go.opentelemetry.io/contrib/instrumentation/runtime"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/propagation"
+	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
+	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
+	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type Option interface {
+	apply(context.Context, *Telemetry) func(ctx context.Context)
+}
+
+type oLog struct {
+	res *resource.Resource
+}
+
+func withOteLog(res *resource.Resource) Option {
+	return &oLog{res: res}
+}
+
+func (o *oLog) apply(ctx context.Context, t *Telemetry) func(context.Context) {
+	// exporter part
+	// this initiation controversy SRP, but right now we just speed up our development
+	opts := []otlploggrpc.Option{otlploggrpc.WithEndpoint(t.cfg.OtelConfig.Addr)}
+	if t.cfg.WithInsecure {
+		opts = append(opts, otlploggrpc.WithInsecure())
+	}
+
+	logExporter, err := otlploggrpc.New(ctx, o.res, opts...)
+	handleErr(err, "Failed to create the collector log exporter")
+
+	batcher := logskd.NewBatchLogProcessor(logExporter)
+	cc := zlogfmt.NewCore(batcher)
+
+	pl := zap.L().WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(core, cc)
+	}))
+
+	zap.ReplaceGlobals(pl)
+
+	// grpc error logger, we use it for debug connection to collector at least
+	//grpclog.SetLoggerV2(grpcerr.New(pl))
+
+	// otel handler also intersect logs
+	//otel.SetErrorHandler(otelerr.New(pl))
+
+	return func(cxt context.Context) {
+		_ = cc.Sync()
+
+		handleErr(batcher.Shutdown(ctx), "batched shutdown")
+		t.Info("OTEL log batch controller have been shutdown")
+	}
+}
+
+//user otel.GetTracerProvider() to reach trace
+type oTrace struct {
+	res *resource.Resource
+}
+
+func withOteTrace(res *resource.Resource) Option {
+	return &oTrace{res: res}
+}
+
+func (o *oTrace) apply(ctx context.Context, t *Telemetry) func(context.Context) {
+	opts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(t.cfg.OtelConfig.Addr)}
+	if t.cfg.OtelConfig.WithInsecure {
+		opts = append(opts, otlptracegrpc.WithInsecure())
+	}
+
+	traceClient := otlptracegrpc.NewClient(opts...,
+	//otlptracegrpc.WithDialOption(grpc.WithBlock()),
+	)
+
+	traceExp, err := otlptrace.New(ctx, traceClient)
+	handleErr(err, "Failed to create the collector trace exporter")
+
+	bsp := sdktrace.NewBatchSpanProcessor(traceExp)
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+		sdktrace.WithResource(o.res),
+		sdktrace.WithSpanProcessor(bsp),
+	)
+
+	// set global propagator to tracecontext (the default is no-op).
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{}, propagation.Baggage{},
+		))
+
+	otel.SetTracerProvider(tracerProvider)
+
+	t.trace = otel.Tracer(GenServiceName(t.cfg.Namespace, t.cfg.Service) + "_tracer")
+
+	return func(ctx context.Context) {
+		handleErr(traceExp.Shutdown(ctx), "trace exporter shutdown")
+		t.Info("OTEL trace exporter have been shutdown")
+	}
+}
+
+type oMetric struct {
+	res *resource.Resource
+}
+
+func withOteMetric(res *resource.Resource) Option {
+	return &oMetric{res: res}
+}
+
+func (o *oMetric) apply(ctx context.Context, t *Telemetry) func(context.Context) {
+	opts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(t.cfg.OtelConfig.Addr)}
+	if t.cfg.OtelConfig.WithInsecure {
+		opts = append(opts, otlpmetricgrpc.WithInsecure())
+	}
+
+	metricClient := otlpmetricgrpc.NewClient(opts...,
+	//otlpmetricgrpc.WithDialOption(grpc.WithBlock()),
+	)
+
+	metricExp, err := otlpmetric.New(ctx, metricClient)
+	handleErr(err, "Failed to create the collector metric exporter")
+
+	pusher := controller.New(
+		processor.NewFactory(
+			simple.NewWithHistogramDistribution(),
+			metricExp,
+			processor.WithMemory(true),
+		),
+		controller.WithExporter(metricExp),
+		controller.WithCollectPeriod(5*time.Second),
+		controller.WithResource(o.res),
+	)
+
+	global.SetMeterProvider(pusher)
+
+	err = pusher.Start(ctx)
+	handleErr(err, "Failed to start metric pusher")
+
+	// runtime exported
+	err = rt.Start()
+	handleErr(err, "Failed to start runtime metric")
+
+	// host metrics exporter
+	err = host.Start()
+	handleErr(err, "Failed to start host metric")
+
+	srvName := GenServiceName(t.cfg.Namespace, t.cfg.Service)
+	t.meter = global.Meter(srvName+"_meter", metric.WithInstrumentationVersion("hello"))
+
+	return func(ctx context.Context) {
+		// pushes any last exports to the receiver
+		handleErr(pusher.Stop(ctx), "trace exporter shutdown")
+		t.Info("OTEL trace exporter have been shutdown")
+	}
+}


### PR DESCRIPTION
* Rid of errors /dev/stderr during closer because of sync - we use OTEL Logger closer for final sync now
* Allow disable OTEL prapagation `OTEL_ENABLE`
* `NewSimple` constructor without OTEL
* Implement options more gracefully OTEL initialization
* Monitor uses options flow for setup and add as composition to Telemetry for `AddHealthChecker` health attach